### PR TITLE
Oligotyping

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,12 +21,17 @@ RUN apt-get update && apt-get install -y \
 	dos2unix \
 	python2.7 \
 	r-base \
-	python-pip
+	python-pip \
+	python-tk
 
 # Install python packages
 RUN python -m pip install --upgrade pip
 RUN pip install numpy scipy
 RUN pip install biopython
+RUN pip install matplotlib
+RUN pip install django
+# Install oligotyping
+RUN pip install oligotyping
 
 RUN mkdir /app/lib
 
@@ -55,6 +60,16 @@ COPY lib/casper /app/lib/casper
 COPY lib/swarm /app/lib/swarm
 COPY lib/mistag_filter /app/lib/mistag_filter
 COPY lib/abundance_filters /app/lib/abundance_filters
+COPY lib/scripts/pad_with_gaps /app/lib/scripts/pad_with_gaps
+COPY lib/R /app/lib/R
+COPY lib/oligotyping /app/lib/oligotyping
+COPY lib/blast /app/lib/blast
+
+# Install R dependencies
+RUN R -f /app/lib/R/install-packages.R
+
+# Make blast programs accessible
+ENV PATH="${PATH}:/app/lib/blast/ncbi-blast-2.6.0+/bin"
 
 # Compile DTD
 RUN cd /app/lib/DTD && make && cd /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,15 @@ RUN apt-get update && apt-get install -y \
 	pkg-config \
 	libboost-all-dev \
 	pigz \
-	dos2unix
+	dos2unix \
+	python2.7 \
+	r-base \
+	python-pip
+
+# Install python packages
+RUN python -m pip install --upgrade pip
+RUN pip install numpy scipy
+RUN pip install biopython
 
 RUN mkdir /app/lib
 
@@ -45,6 +53,8 @@ COPY lib/pandaseq /app/lib/pandaseq
 COPY lib/vsearch /app/lib/vsearch
 COPY lib/casper /app/lib/casper
 COPY lib/swarm /app/lib/swarm
+COPY lib/mistag_filter /app/lib/mistag_filter
+COPY lib/abundance_filters /app/lib/abundance_filters
 
 # Compile DTD
 RUN cd /app/lib/DTD && make && cd /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,7 @@ COPY lib/vsearch /app/lib/vsearch
 COPY lib/casper /app/lib/casper
 COPY lib/swarm /app/lib/swarm
 COPY lib/mistag_filter /app/lib/mistag_filter
+COPY lib/abundance_filters /app/lib/abundance_filters
 
 # Compile DTD
 RUN cd /app/lib/DTD && make && cd /app

--- a/server/modules/mistag_filter.js
+++ b/server/modules/mistag_filter.js
@@ -1,0 +1,51 @@
+const spawn = require('child_process').spawn;
+const fs = require('fs');
+
+exports.name = 'mistag_filter';
+exports.multicore = false;
+exports.category = 'Filtering';
+
+exports.run = (os, config, callback) => {
+	var token = os.token;
+	var directory = '/app/data/' + token + '/';
+
+	// Input fasta file name (required)
+	var filename = directory + config.params.inputs.fasta;
+	// Multiplexing design file
+	var design = directory + config.params.inputs.design
+	// Output fasta file name
+	var out_file = directory + config.params.outputs.fasta;
+
+	console.log ('Mistag filtering for file ' + filename);
+  
+	// Alpha level for finding the Student's T critical value for the modified Thompson Tau rejection region calulation (default = 0.05)
+	var alpha = config.params.params.alpha
+
+	// Command line
+	var options = ['-i', filename,
+		'-d', design,
+		'-a', alpha,
+		'-o', out_file];
+
+	if (config.params.params.out == 'true')
+		options = options.concat(['--out'])
+
+	console.log('Command:\nmistag_filter.py', options.join(' '));
+
+	// Execution
+	var child = spawn('/app/lib/mistag_filter/mistag_filter.py', options);
+	child.stdout.on('data', function(data) {
+		fs.appendFileSync(directory + config.log, data);
+	});
+	child.stderr.on('data', function(data) {
+		fs.appendFileSync(directory + config.log, data);
+	});
+	child.on('close', (code) => {
+		if (code != 0) {
+			console.log("Error code " + code + " during mistag_filter.py");
+			callback(os, code);
+		} else {
+			callback(os, null);
+		}
+	});
+};

--- a/server/modules/oligotyping.js
+++ b/server/modules/oligotyping.js
@@ -1,0 +1,162 @@
+const spawn = require('child_process').spawn;
+const fs = require('fs');
+const tools = require('../toolbox.js');
+
+exports.name = 'oligotyping';
+exports.multicore = false;
+exports.category = 'Clustering';
+exports.run = (os, config, callback) => {
+	var token = os.token;
+	var tmp_outfile = tools.tmp_filename() + '_padded.fasta';
+	// Input fasta file name (required)
+	var filename = config.params.inputs.fasta;
+	// Output directory
+	var out_dir = config.params.outputs.outDir;
+
+	var options = config.params.params;
+
+	var padding = options.padding;
+	if (padding == 'true') {
+		let config_pad = {params: {
+			inputs: {fasta: filename},
+			outputs: {fasta: tmp_outfile},
+			params: {}
+		}, log: config.log};
+		pad(os, config_pad, options, out_dir, callback);
+	} else {
+		var entropy_out = filename + '-ENTROPY';
+		let config_ent = {params: {
+			inputs: {fasta: filename},
+			outputs: {entropy: entropy_out},
+			params: {}
+		}, log: config.log};
+		entropy(os, config_ent, options, out_dir, callback);
+	}
+};
+
+
+var gzip_it = function (os, out_dir, callback) {
+	var directory = '/app/data/' + os.token + '/';
+	var folder = directory + out_dir;
+	console.log('Gzipping output folder ' + folder);
+	command = ['-zcvf', folder, '-C', folder.replace('.tar.gz', '/'), '.']
+	console.log('Command:\ntar', command.join(' '));
+	var gzip_run = spawn('tar', command);
+	gzip_run.on('close', (code) => {
+		// no effect on folder
+		fs.unlink(folder.replace('.tar.gz', ''), () => {});
+		if (code != 0) {
+			console.log("Error code " + code + " during folder compression");
+			callback(os, code);
+		} else {
+			callback(os, null);
+		}
+	});
+};
+
+
+var oligotyping = function (os, config, options, out_dir, callback) {
+	var directory = '/app/data/' + os.token + '/';
+	var fasta = config.params.inputs.fasta;
+	var entropy = config.params.outputs.entropy;
+	// Params
+	command = [directory + fasta, directory + entropy,
+		'-o', directory + out_dir.replace('.tar.gz', '/'),
+		'-s', options.sample,
+		'-a', options.abund,
+		'-A', options.abundSum,
+		'-M', options.abundOligo,
+		// to be removed when tk-python bug solved
+		'--no-display', '--no-figures',
+		'-t', options.sep];
+
+	if (options.auto != '')
+		command = command.concat(['-c', options.auto]);
+	if (options.manu != '')
+		command = command.concat(['-C', options.manu.replace(/^\s+|\s+$/g, '').split(' ').join(',')]);
+	// to be added when tk-python bug solved
+	//if (options.display == 'false')
+	//	command = command.concat(['--no-display', '--no-figures']);
+	if (options.sets == 'true')
+		command = command.concat(['--generate-sets']);
+	if (options.basic == 'true')
+		command = command.concat(['--skip-basic-analyses']);
+	if (options.gefx == 'true')
+		command = command.concat(['--skip-gexf-network-file', '--skip-gen-html']);
+
+	console.log('Command:\noligotype', command.join(' '));
+	var oligotype_run = spawn('oligotype', command);
+	oligotype_run.stdout.on('data', function(data) {
+		fs.appendFileSync(directory + config.log, data);
+	});
+	oligotype_run.stderr.on('data', function(data) {
+		fs.appendFileSync(directory + config.log, data);
+	});
+	oligotype_run.on('close', (code) => {
+		fs.unlink(directory + entropy, () => {});
+		if (fasta.endsWith("_padded.fasta"))
+			fs.unlink(directory + fasta, () => {});
+		if (code != 0) {
+			console.log("Error code " + code + " during oligotyping");
+			callback(os, code);
+		} else {
+			gzip_it(os, out_dir, (os, msg) => {
+				callback(os, msg);
+			});
+		}
+	});
+};
+
+
+var entropy = function (os, config, options, out_dir, callback) {
+	var directory = '/app/data/' + os.token + '/';
+	var fasta = config.params.inputs.fasta;
+	var entropy = config.params.outputs.entropy;
+	console.log('Calculating entropy traces on ' + fasta);
+	var command = [directory + fasta, '--quick', '--no-display'];
+	console.log('entropy-analysis ' + command.join(' '));
+	var calc_entropy = spawn('entropy-analysis', command);
+	calc_entropy.stdout.on('data', function(data) {
+		fs.appendFileSync(directory + config.log, data);
+	});
+	calc_entropy.stderr.on('data', function(data) {
+		fs.appendFileSync(directory + config.log, data);
+	});
+	calc_entropy.on('close', (code) => {
+		// WRONG RETURN CODE???
+		if (code > 1) {
+			console.log("Error code " + code + " during entropy-analysis");
+			callback(os, code);
+		} else {
+			oligotyping(os, config, options, out_dir, (os, msg) => {
+				callback(os, msg);
+			});
+		}
+	});
+};
+
+
+var pad = function (os, config, options, out_dir, callback) {
+	var directory = '/app/data/' + os.token + '/';
+	var fasta_in = config.params.inputs.fasta;
+	var fasta_out = config.params.outputs.fasta;
+	var entropy_out = fasta_out + '-ENTROPY';
+	console.log('Padding fasta: ' + fasta_in);
+	var command = ['-i', directory + fasta_in, '-o', directory + fasta_out];
+	console.log('/app/lib/scripts/pad_with_gaps/pad_with_gaps.py', command.join(' ') + '\n');
+	var pad = spawn('/app/lib/scripts/pad_with_gaps/pad_with_gaps.py', command);
+	pad.on('close', (code) => {
+		if (code != 0) {
+			console.log("Error code " + code + " during pad_with_gaps.py");
+			callback(os, code);
+		} else {
+			let config_ent = {params: {
+				inputs: {fasta: fasta_out},
+				outputs: {entropy: entropy_out},
+				params: {}}, log: config.log};
+			entropy(os, config_ent, options, out_dir, (os, msg) => {
+				callback(os, msg);
+			});
+		}
+	});
+};

--- a/update_dependencies.sh
+++ b/update_dependencies.sh
@@ -95,3 +95,33 @@ else
 	git pull
 	cd ..
 fi
+
+
+# Blast+
+if [ ! -d "blast" ]; then
+	mkdir blast
+	wget -qO- ftp://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/LATEST/ncbi-blast-2.6.0+-x64-linux.tar.gz | tar xvz -C blast/
+fi
+
+
+# pad_with_gaps
+if [ ! -d "scripts" ]; then
+	mkdir scripts
+	if [ ! -d "scripts/pad_with_gaps" ]; then
+		git clone https://github.com/FranckLejzerowicz/pad_with_gaps.git scripts/pad_with_gaps/
+	else
+		cd scripts/pad_with_gaps
+		git pull
+		cd ../..
+	fi
+else
+	cd scripts
+	if [ ! -d "pad_with_gaps" ]; then
+		git clone https://github.com/FranckLejzerowicz/pad_with_gaps.git pad_with_gaps/
+	else
+		cd pad_with_gaps
+		git pull
+		cd ..
+	cd ..
+	fi
+fi

--- a/update_dependencies.sh
+++ b/update_dependencies.sh
@@ -78,4 +78,21 @@ else
 fi
 
 
+# mistag_filter
+if [ ! -d "mistag_filter" ]; then
+	git clone https://github.com/FranckLejzerowicz/mistag_filter.git mistag_filter/
+else
+	cd mistag_filter
+	git pull
+	cd ..
+fi
+
+# abundance_filters
+if [ ! -d "abundance_filters" ]; then
+	git clone https://github.com/FranckLejzerowicz/abundance_filters.git abundance_filters/
+else
+	cd abundance_filters
+	git pull
+	cd ..
+fi
 

--- a/update_dependencies.sh
+++ b/update_dependencies.sh
@@ -86,3 +86,12 @@ else
 	git pull
 	cd ..
 fi
+
+# abundance_filters
+if [ ! -d "abundance_filters" ]; then
+	git clone https://github.com/FranckLejzerowicz/abundance_filters.git abundance_filters/
+else
+	cd abundance_filters
+	git pull
+	cd ..
+fi

--- a/www/modules/mistag_filter.html
+++ b/www/modules/mistag_filter.html
@@ -1,0 +1,22 @@
+<p>Fasta file</p>
+<input type="text" name="fasta" class="input_file fasta" />
+
+<p>Design file</p>
+<input type="text" name="design" class="input_file tsv txt" />
+
+<p>Mistag-filtered fasta file</p>
+<span class="output_zone">
+	<input type="text" name="fasta" value='mistagFiltered.fasta' />
+	<a href="" download><img src="/imgs/download.png" class="download"/></a>
+</span>
+
+<div class="options">
+	<p>
+		Alpha level for Student's T critical value: 
+		<input type="text" name="alpha" class="integer number param_value" value="0.05">
+	</p>
+	<p>
+		Leave expected sample sequences out of non-critical mistags distribution
+		<input type="checkbox" name="out" class="param_value outMistag">
+	</p>
+</div>

--- a/www/modules/mistag_filter.html
+++ b/www/modules/mistag_filter.html
@@ -8,6 +8,9 @@
 <span class="output_zone">
 	<input type="text" name="fasta" value='mistagFiltered.fasta' />
 	<a href="" download><img src="/imgs/download.png" class="download"/></a>
+	<p><i>associated statistics file (not editable)</i></p>
+	<input type="text" name="stats" value='mistagFiltered_stats.tsv' style="background-color:#d3d3d3;" readonly>
+	<a href="" download><img src="/imgs/download.png" class="download"/></a>
 </span>
 
 <div class="options">

--- a/www/modules/mistag_filter.js
+++ b/www/modules/mistag_filter.js
@@ -12,8 +12,11 @@ class MistagFilterModule extends Module {
 		var inputfasta = this.dom.getElementsByClassName('input_file')[0];
 		inputfasta.onchange = () => {
 			let mistagfasta = that.dom.getElementsByClassName('output_zone')[0].getElementsByTagName('input')[0];
+			let mistagstats = that.dom.getElementsByClassName('output_zone')[0].getElementsByTagName('input')[1];
 			mistagfasta.value = inputfasta.value.substr(0, inputfasta.value.lastIndexOf('.')) + '_mistagFiltered.fasta';
+			mistagstats.value = inputfasta.value.substr(0, inputfasta.value.lastIndexOf('.')) + '_mistagFiltered_stats.tsv';
 			mistagfasta.onchange();
+			mistagstats.onchange();
 		};
 	}
 

--- a/www/modules/mistag_filter.js
+++ b/www/modules/mistag_filter.js
@@ -1,0 +1,31 @@
+
+class MistagFilterModule extends Module {
+	constructor (params) {
+		super ("mistag_filter", "https://github.com/FranckLejzerowicz/mistag_filter/wiki/Mistag_filter_module");
+
+		this.params = params;
+	}
+
+	onLoad () {
+		super.onLoad();
+		var that = this;
+		var inputfasta = this.dom.getElementsByClassName('input_file')[0];
+		inputfasta.onchange = () => {
+			let mistagfasta = that.dom.getElementsByClassName('output_zone')[0].getElementsByTagName('input')[0];
+			mistagfasta.value = inputfasta.value.substr(0, inputfasta.value.lastIndexOf('.')) + '_mistagFiltered.fasta';
+			mistagfasta.onchange();
+		};
+	}
+
+	getConfiguration () {
+		var config = super.getConfiguration()
+		config.params.out = this.dom.getElementsByClassName('outMistag')[0].checked;
+		return config;
+	}
+};
+
+
+module_manager.moduleCreators['mistag_filter'] = (params) => {
+	return new MistagFilterModule(params);
+};
+

--- a/www/modules/oligotyping.html
+++ b/www/modules/oligotyping.html
@@ -1,0 +1,36 @@
+<p>Padded fasta file</p>
+<input type="text" name="fasta" class="input_file fasta">
+
+<p>Output directory (will be compressed)</p>
+<span class="output_zone">
+	<input type="text" name="outDir" value="">
+	<a href="" download><img src="/imgs/download.png" class="download"/></a>
+</span>
+
+<p>Components of the entropy trace</p>
+<p>
+Number (auto) <input type="number" name="auto" class="param_value autoCompo" value="1" style="width: 50px;">
+Selection (manual) <input type="text" name="manu" class="param_value manuCompo" style="width: 120px;">
+</p>
+<p>Abundance thresholds</p>
+<p>
+Min samples occurrence <input type="number" name="sample" class="param_value nSamples" value="1" style="width: 50px;">
+Min percent abundance <input type="number" name="abund" class="param_value pAbund" value="0.0" pattern="[0-9]+([\.,][0-9]+)?" step="0.01" title="Number with up to 2 decimal places" style="width: 60px;">
+</p>
+<p>
+Across dataset <input type="number" name="abundSum" class="param_value abundSum" value="0" style="width: 50px;">
+Biggest oligotype <input type="number" name="abundOligo" class="param_value abundOligo" value="0" style="width: 50px;">
+</p>
+
+<div class="options">
+	<p>Perform padding <input type="checkbox" name="padding" class="param_value padding" checked>
+	<!-- to be added when tk-python bug fixed -->
+	<!-- Figure display <input type="checkbox" name="display" class="param_value display">-->
+	Sample name separator <input type="text" name="sep" class="param_value sep" value="_" style="width: 30px;">
+	Make oligotype sets <input type="checkbox" name="sets" class="param_value sets" checked>
+	</p>
+	<p>
+	Skip basic analyses <input type="checkbox" name="basic" class="param_value basic" checked>
+	Skip GEFX network <input type="checkbox" name="gefx" class="param_value gefx" checked></p>
+	</p>
+</div>

--- a/www/modules/oligotyping.js
+++ b/www/modules/oligotyping.js
@@ -1,0 +1,87 @@
+
+class OligotypingModule extends Module {
+	constructor (params) {
+		super ("oligotyping");
+		this.params = params;
+	}
+
+	onLoad () {
+		super.onLoad();
+		var that = this;
+		var what = this;
+		var thing = this;
+		var fasta = this.dom.getElementsByClassName('fasta')[0];
+		var c_param = what.dom.getElementsByClassName('autoCompo')[0];
+		var sc_param = that.dom.getElementsByClassName('manuCompo')[0];
+		var s_param = that.dom.getElementsByClassName('nSamples')[0];
+		var a_param = that.dom.getElementsByClassName('pAbund')[0];
+		var A_param = that.dom.getElementsByClassName('abundSum')[0];
+		var M_param = that.dom.getElementsByClassName('abundOligo')[0];
+
+		this.fasta = fasta;
+		this.c_param = c_param;
+        this.sc_param = sc_param;
+        this.s_param = s_param;
+        this.a_param = a_param;
+        this.A_param = A_param;
+        this.M_param = M_param;
+
+		this.c_param.onchange = () => {that.c_change()};
+		this.sc_param.onchange = () => {what.sc_change()};
+		this.fasta.onchange = this.s_param.onchange = this.a_param.onchange = this.A_param.onchange = this.M_param.onchange = () => {thing.input_change()};
+	}
+
+	c_change () {
+		let manuCompo = this.dom.getElementsByClassName('manuCompo')[0];
+		let dir = this.dom.getElementsByClassName('output_zone')[0].getElementsByTagName('input')[0];
+		var fasta = this.dom.getElementsByClassName('input_file')[0];
+		if (this.c_param.value != '') {
+			this.sc_param.value = '';
+		} else {
+			manuCompo.value = this.sc_param.value;
+		}
+		dir.value = fasta.value.substr(0, fasta.value.lastIndexOf('.'));
+		if (this.c_param.value != '')
+			dir.value = dir.value + '-c' + this.c_param.value;
+		if (this.sc_param.value != '')
+			dir.value = dir.value + '-sc' + this.sc_param.value;
+		dir.value = dir.value + '-a' + this.a_param.value + '-A' + this.A_param.value + '-M' + this.M_param.value + '.tar.gz';
+		dir.onchange();
+	}
+
+	sc_change () {
+		let autoCompo = this.dom.getElementsByClassName('autoCompo')[0];
+		let dir = this.dom.getElementsByClassName('output_zone')[0].getElementsByTagName('input')[0];
+		var fasta = this.dom.getElementsByClassName('input_file')[0];
+		if (this.sc_param.value != '') {
+			this.c_param.value = '';
+		} else {
+			autoCompo.value = this.c_param.value;;
+		}
+		dir.value = fasta.value.substr(0, fasta.value.lastIndexOf('.'));
+		if (this.c_param.value != '')
+			dir.value = dir.value + '-c' + this.c_param.value;
+		if (this.sc_param.value != '')
+			dir.value = dir.value + '-sc' + this.sc_param.value.replace(/[&\/\\#,+()$~%.'":*?<>{}]/g,'').split(' ').length;
+		dir.value = dir.value + '-a' + this.a_param.value + '-A' + this.A_param.value + '-M' + this.M_param.value + '.tar.gz';
+		dir.onchange();
+	}
+
+	input_change () {
+		let dir = this.dom.getElementsByClassName('output_zone')[0].getElementsByTagName('input')[0];
+		var fasta = this.dom.getElementsByClassName('input_file')[0];
+		dir.value = fasta.value.substr(0, fasta.value.lastIndexOf('.'));
+		if (this.c_param.value != '')
+			dir.value = dir.value + '-c' + this.c_param.value;
+		if (this.sc_param.value != '')
+			dir.value = dir.value + '-sc' + this.sc_param.value;
+		dir.value = dir.value + '-a' + this.a_param.value + '-A' + this.A_param.value + '-M' + this.M_param.value + '.tar.gz';
+		dir.onchange();
+	}
+};
+
+
+module_manager.moduleCreators['oligotyping'] = (params) => {
+	return new OligotypingModule(params);
+};
+


### PR DESCRIPTION
** Oligotyping module integration **

All the files for client and server aspects of the module:
- server/modules/oligotyping.js
- www/modules/oligotyping.js
- www/modules/oligotyping.html
ipdate_dependencies.sh appended with:
- Blast+ download
- pad_with_gaps.py python script pulling from githug
Dockerfile updated for several oligotyping requirements

The program basic functioning is tested and validated.

The option ```--no-figures``` is strictly activated and it will only be possible to inactivate it in the future when an issue about a Docker install of python-tk will be solved (see commented line in client files).

This Pull Request may be completed with a set of test files in a potentially future folder /lib/oligotyping.

Note that the lines not corresponding to the Oligotyping module are present because they were submitted in previous commits from different fork branches, namely "master" (for mistag_filter), and "abundance_filters" (for abundance_filters).